### PR TITLE
docs: add makefile help target

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Other Languages: [English](README.md) | [繁體中文](README.zh-TW.md) | [简�
 - Dev server at `0.0.0.0:9987`; bilingual docs scaffolded
 - Docs generator script: by class/file, optional notebook execution, concurrency, preserves folder structure
 - Async file processing via anyio and rich progress bars
-- Packaging with `uv build`, fancy PyPI README (hatch‑fancy‑pypi‑readme), changelog via git‑cliff
+- Packaging with `uv build` and changelog via `git-cliff`
 - Automatic PEP 440 versioning from git via `dunamai` in CI
 - Dockerfile multi‑stage with uv/uvx and Node.js; Compose services (Redis/Postgres/Mongo/MySQL) with healthchecks and volumes
 - GitHub Actions: tests, quality, docs deploy, package build, docker image publish (GHCR with buildx cache), release drafter, auto labeler, secret scan, semantic PR, pre‑commit auto‑update
@@ -45,7 +45,7 @@ Other Languages: [English](README.md) | [繁體中文](README.zh-TW.md) | [简�
 
 Prerequisites:
 
-- Python 3.10–3.12
+- Python 3.10–3.13
 - `uv` (install with `make uv-install`)
 - Pre-commit hooks: either `uv tool install pre-commit` or `uv sync --group dev`
 
@@ -84,6 +84,7 @@ find . -type f -name "*.py" -o -name "*.md" -o -name "*.toml" | xargs sed -i 's/
 
 ```bash
 # Development
+make help               # List available make targets
 make clean              # Clean caches, artifacts and generated docs
 make format             # Run all pre-commit hooks
 make test               # Run pytest across the repository
@@ -208,7 +209,7 @@ All workflows live in `.github/workflows/`. This section explains what each acti
 - Tests (`test.yml`)
 
     - Trigger: Pull requests to `master` or `release/*` (ignores md files)
-    - Runs pytest on Python 3.10/3.11/3.12 with coverage and comments a summary
+    - Runs pytest on Python 3.10/3.11/3.12/3.13 with coverage and comments a summary
     - Setup needed: none
 
 - Code Quality Check (`code-quality-check.yml`)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,7 +32,7 @@
     - 开发服务器 `0.0.0.0:9987`；双语文档脚手架
 - 文档生成脚本：支持 class/文件两种模式、可选执行 notebook、可并发、保留目录结构
     - 使用 anyio 异步处理与 rich 进度条
-- 打包：`uv build`、PyPI README（hatch-fancy-pypi-readme）、git-cliff 产 changelog
+- 打包：`uv build`、git-cliff 产 changelog
 - CI 自动版本：以 `dunamai` 从 git 产 PEP 440 版本
 - Dockerfile 多阶段（内含 uv/uvx 与 Node.js）；Compose 服务（Redis/Postgres/Mongo/MySQL）含 healthcheck 与 volume
 - GitHub Actions：测试、质量、文档部署、包打包、Docker 推送（GHCR + buildx cache）、Release Drafter、自动标签、秘密扫描、语义化 PR、pre-commit 自动更新
@@ -45,7 +45,7 @@
 
 需求：
 
-- Python 3.10–3.12
+- Python 3.10–3.13
 - `uv`（可用 `make uv-install` 安装）
 - pre-commit hooks：`uv tool install pre-commit` 或 `uv sync --group dev`
 
@@ -84,6 +84,7 @@ find . -type f -name "*.py" -o -name "*.md" -o -name "*.toml" | xargs sed -i 's/
 
 ```bash
 # 开发
+make help               # 显示 Makefile 命令列表
 make clean              # 清理缓存、产物与产生的文档
 make format             # 执行所有 pre-commit hooks
 make test               # 执行 pytest
@@ -208,7 +209,7 @@ uvx poe docs
 - Tests（`test.yml`）
 
     - 触发：对 `master`、`release/*` 的 PR
-    - 执行 pytest（3.10/3.11/3.12）并留下覆盖率摘要
+    - 执行 pytest（3.10/3.11/3.12/3.13）并留下覆盖率摘要
 
 - Code Quality（`code-quality-check.yml`）
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -32,7 +32,7 @@
     - 開發伺服器 `0.0.0.0:9987`；雙語文件腳手架
 - 文件生成腳本：支援 class/檔案兩種模式、可選執行 notebook、可併發、保留目錄結構
     - 使用 anyio 非同步處理與 rich 進度條
-- 打包：`uv build`、PyPI README（hatch-fancy-pypi-readme）、git-cliff 產 changelog
+- 打包：`uv build`、git-cliff 產 changelog
 - CI 自動版本：以 `dunamai` 從 git 產 PEP 440 版本
 - Dockerfile 多階段（內含 uv/uvx 與 Node.js）；Compose 服務（Redis/Postgres/Mongo/MySQL）含 healthcheck 與 volume
 - GitHub Actions：測試、品質、文件部署、套件打包、Docker 推送（GHCR + buildx cache）、Release Drafter、自動標籤、祕密掃描、語義化 PR、pre-commit 自動更新
@@ -45,7 +45,7 @@
 
 需求：
 
-- Python 3.10–3.12
+- Python 3.10–3.13
 - `uv`（可用 `make uv-install` 安裝）
 - pre-commit hooks：`uv tool install pre-commit` 或 `uv sync --group dev`
 
@@ -84,6 +84,7 @@ find . -type f -name "*.py" -o -name "*.md" -o -name "*.toml" | xargs sed -i 's/
 
 ```bash
 # 開發
+make help               # 顯示 Makefile 指令列表
 make clean              # 清理快取、產物與產生的文件
 make format             # 執行所有 pre-commit hooks
 make test               # 執行 pytest
@@ -208,7 +209,7 @@ uvx poe docs
 - Tests（`test.yml`）
 
     - 觸發：對 `master`、`release/*` 的 PR
-    - 執行 pytest（3.10/3.11/3.12）並留下覆蓋率摘要
+    - 執行 pytest（3.10/3.11/3.12/3.13）並留下覆蓋率摘要
 
 - Code Quality（`code-quality-check.yml`）
 


### PR DESCRIPTION
## Summary
- mention `make help` in command reference
- sync Chinese READMEs with Makefile help info

## Testing
- `uv run pre-commit run --files README.md README.zh-TW.md README.zh-CN.md`
- `uv sync --group test`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c12785f3448321ab1bdcde359dc223