### PR TITLE
feat: add ty type checker ahead of mypy

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -77,7 +77,7 @@ uv python install 3.12
 Common tasks are exposed via the `Makefile`. Run `make help` to list all targets. Frequently used ones:
 
 ```bash
-make fmt       # Run pre-commit hooks (ruff, mdformat, codespell, mypy, ...)
+make fmt       # Run pre-commit hooks (ruff, mdformat, codespell, ty, mypy, ...)
 make test      # Run the test suite
 make gen-docs  # Generate documentation
 make clean     # Remove caches and build artifacts
@@ -173,7 +173,7 @@ Pull requests are typically merged via **squash merge** to keep history linear.
 ## Coding Standards
 
 - **Formatting and linting**: handled by `ruff` (configured in `pyproject.toml`)
-- **Typing**: `mypy` is configured with the Pydantic plugin; new code should be type-annotated
+- **Typing**: `ty` runs first with strict rules; `mypy` (with the Pydantic plugin) runs alongside during the migration; new code should be type-annotated
 - **Spelling**: enforced by `codespell` via pre-commit
 - **Notebooks**: stripped of outputs by `nbstripout`
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,7 +54,7 @@ make fmt                      # Run pre-commit hooks
 
 ### Common Commands
 
-- `make fmt` or `uv run pre-commit run -a` - Run ALL pre-commit hooks (ruff, mypy, mdformat, codespell, nbstripout, gitleaks)
+- `make fmt` or `uv run pre-commit run -a` - Run ALL pre-commit hooks (ruff, ty, mypy, mdformat, codespell, nbstripout, gitleaks)
 - `make test` - Run pytest with coverage (80% minimum, fails below threshold)
 - `make clean` - Remove all build artifacts, caches, and generated docs
 - `make gen-docs` - Generate API docs from `src/` and `scripts/` into `docs/Reference/` and `docs/Scripts/`
@@ -213,7 +213,7 @@ When creating or modifying `.github/workflows/*.yml` files, adhere to the follow
 ### Code Quality (.github/workflows/code-quality-check.yml)
 
 - Runs all pre-commit hooks via `uv run pre-commit run -a`
-- Includes ruff check, ruff format, mypy, and other linters
+- Includes ruff check, ruff format, ty, mypy, and other linters
 - Enforces pre-commit hook standards
 
 ### Documentation Deploy (.github/workflows/deploy.yml)
@@ -352,7 +352,7 @@ make test                     # Verify tests pass
 
 ## Critical Usage Guidelines
 
-- **After every code change, always run `uv run pre-commit run -a` (or `make fmt`) before committing to ensure all hooks (ruff, mypy, mdformat, codespell, etc.) pass.**
+- **After every code change, always run `uv run pre-commit run -a` (or `make fmt`) before committing to ensure all hooks (ruff, ty, mypy, mdformat, codespell, etc.) pass.**
 - **All commit messages and PR titles must be in English and follow [Conventional Commits](https://www.conventionalcommits.org/)** (e.g. `feat: add login page`, `fix(api): handle null response`)
 - Always use `uv sync` for installing dependencies, never use `pip install`
 - Always prefix script execution with `uv run <command>` to ensure correct environment

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -113,6 +113,9 @@ repos:
     rev: v0.0.63
     hooks:
       - id: ty
+        # ty checks the whole repo (src, tests, scripts), so its environment
+        # needs every dependency group, not just the default ones.
+        args: ["--all-groups"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v2.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -109,6 +109,11 @@ repos:
         additional_dependencies:
           - tomli
 
+  - repo: https://github.com/astral-sh/ty-pre-commit
+    rev: v0.0.63
+    hooks:
+      - id: ty
+
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v2.3.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![python](https://img.shields.io/badge/-Python_%7C_3.12%7C_3.13%7C_3.14-blue?logo=python&logoColor=white)](https://www.python.org/downloads/source/)
 [![uv](https://img.shields.io/badge/-uv_dependency_management-2C5F2D?logo=python&logoColor=white)](https://docs.astral.sh/uv/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)
 [![Pydantic v2](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/pydantic/pydantic/main/docs/badge/v2.json)](https://docs.pydantic.dev/latest/contributing/#badges)
 [![tests](https://github.com/Mai0313/repo_template/actions/workflows/test.yml/badge.svg)](https://github.com/Mai0313/repo_template/actions/workflows/test.yml)
 [![code-quality](https://github.com/Mai0313/repo_template/actions/workflows/code-quality-check.yml/badge.svg)](https://github.com/Mai0313/repo_template/actions/workflows/code-quality-check.yml)
@@ -28,8 +29,8 @@ Other Languages: [English](README.md) | [繁體中文](README.zh-TW.md) | [简�
 
 - Modern `src/` layout and type‑hinted code
 - Fast dependency management via `uv`
-- Pre‑commit suite: ruff, mdformat(+plugins), codespell, nbstripout, mypy, uv hooks
-- Strong typing: mypy with Pydantic plugin configuration
+- Pre‑commit suite: ruff, mdformat(+plugins), codespell, nbstripout, ty, mypy, uv hooks
+- Strong typing: ty with strict rules; mypy runs alongside during the migration
 - Pytest with coverage and xdist; PR coverage summary comment
 - Coverage gate at 80% with HTML/XML reports committed under `.github/`
 - Zensical with mkdocstrings (inheritance diagrams), markdown‑exec, MathJax

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,6 +6,7 @@
 [![python](https://img.shields.io/badge/-Python_%7C_3.12%7C_3.13%7C_3.14-blue?logo=python&logoColor=white)](https://www.python.org/downloads/source/)
 [![uv](https://img.shields.io/badge/-uv_dependency_management-2C5F2D?logo=python&logoColor=white)](https://docs.astral.sh/uv/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)
 [![Pydantic v2](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/pydantic/pydantic/main/docs/badge/v2.json)](https://docs.pydantic.dev/latest/contributing/#badges)
 [![tests](https://github.com/Mai0313/repo_template/actions/workflows/test.yml/badge.svg)](https://github.com/Mai0313/repo_template/actions/workflows/test.yml)
 [![code-quality](https://github.com/Mai0313/repo_template/actions/workflows/code-quality-check.yml/badge.svg)](https://github.com/Mai0313/repo_template/actions/workflows/code-quality-check.yml)
@@ -28,8 +29,8 @@
 
 - 现代 `src/` 布局 + 全面类型注解
 - `uv` 超快依赖管理
-- pre-commit 包链：ruff、mdformat（含多插件）、codespell、nbstripout、mypy、uv hooks
-- 类型严谨：mypy + Pydantic 插件设置
+- pre-commit 包链：ruff、mdformat（含多插件）、codespell、nbstripout、ty、mypy、uv hooks
+- 类型严谨：ty 严格规则；迁移期间与 mypy 并行
 - pytest + coverage + xdist；PR 覆盖率摘要留言
     - 覆盖率门槛 80%，HTML/XML 报告输出至 `.github/`
 - Zensical + mkdocstrings（继承图）、markdown-exec、MathJax

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -6,6 +6,7 @@
 [![python](https://img.shields.io/badge/-Python_%7C_3.12%7C_3.13%7C_3.14-blue?logo=python&logoColor=white)](https://www.python.org/downloads/source/)
 [![uv](https://img.shields.io/badge/-uv_dependency_management-2C5F2D?logo=python&logoColor=white)](https://docs.astral.sh/uv/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)
 [![Pydantic v2](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/pydantic/pydantic/main/docs/badge/v2.json)](https://docs.pydantic.dev/latest/contributing/#badges)
 [![tests](https://github.com/Mai0313/repo_template/actions/workflows/test.yml/badge.svg)](https://github.com/Mai0313/repo_template/actions/workflows/test.yml)
 [![code-quality](https://github.com/Mai0313/repo_template/actions/workflows/code-quality-check.yml/badge.svg)](https://github.com/Mai0313/repo_template/actions/workflows/code-quality-check.yml)
@@ -28,8 +29,8 @@
 
 - 現代 `src/` 佈局 + 全面型別註解
 - `uv` 超快依賴管理
-- pre-commit 套件鏈：ruff、mdformat（含多插件）、codespell、nbstripout、mypy、uv hooks
-- 型別嚴謹：mypy + Pydantic 外掛設定
+- pre-commit 套件鏈：ruff、mdformat（含多插件）、codespell、nbstripout、ty、mypy、uv hooks
+- 型別嚴謹：ty 嚴格規則；遷移期間與 mypy 並行
 - pytest + coverage + xdist；PR 覆蓋率摘要留言
     - 覆蓋率門檻 80%，HTML/XML 報告輸出至 `.github/`
 - Zensical + mkdocstrings（繼承圖）、markdown-exec、MathJax

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -328,6 +328,7 @@ select = [
     # "ERA",  # eradicate
     "PD",  # pandas-vet
     # "PGH",  # pygrep-hooks
+    "PGH003",  # pygrep-hooks: blanket-type-ignore
     "PL",  # Pylint
     # "TRY",  # tryceratops
     "FLY",  # flynt
@@ -479,6 +480,30 @@ count = false
 quiet-level = 3
 # the correct one is Amoeba, but we use pronunciation in Chinese to name it.
 ignore-words-list = ["ameba", "mke"]
+
+
+# ================== #
+#         ty         #
+# ================== #
+
+# Gradually migrating from mypy to ty; ty runs before mypy in pre-commit.
+# https://docs.astral.sh/ty/reference/configuration
+# https://docs.astral.sh/ty/reference/rules
+# Based on: https://docs.astral.sh/ty/coming-from-mypy-or-pyright/#stricter-checking-with-ty
+[tool.ty.rules]
+blanket-ignore-comment = "error"
+missing-type-argument = "error"
+possibly-unresolved-reference = "warn"
+unsupported-dynamic-base = "warn"
+
+# NOTE: the following rules are known to have a significant number of false positives,
+# which is mostly unavoidable. Enable them at your own risk!
+division-by-zero = "warn"
+possibly-missing-attribute = "warn"
+possibly-missing-import = "warn"
+
+[tool.ty.analysis]
+strict-literal-narrowing = true
 
 
 # ================== #


### PR DESCRIPTION
## Summary

Start the gradual migration from mypy to [ty](https://github.com/astral-sh/ty). ty now runs **before** mypy in pre-commit; mypy stays until ty covers its remaining gaps (`exhaustive-match`, `unreachable`, `no-any-return`, `import-untyped`, etc.).

- Add the `ty` hook ([astral-sh/ty-pre-commit](https://github.com/astral-sh/ty-pre-commit) v0.0.63) before `mirrors-mypy`. The hook runs `uv check`, resolving dependencies from `pyproject.toml` directly, so no `additional_dependencies` are needed.
- Add `[tool.ty.rules]` / `[tool.ty.analysis]` to `pyproject.toml`, adopting the official ["even stricter" configuration](https://docs.astral.sh/ty/coming-from-mypy-or-pyright/#stricter-checking-with-ty), and enable Ruff `PGH003` (the Ruff half of that same configuration; `ANN`/`PYI` were already selected).
- Add the official ty badge to all three READMEs and mention ty in CONTRIBUTING and copilot-instructions.

No changes to `code-quality-check.yml`: it runs `pre-commit run -a`, so hook order comes from `.pre-commit-config.yaml`.

Existing mypy checks are already covered by ty defaults (verified against the official [rule mapping table](https://docs.astral.sh/ty/coming-from-mypy-or-pyright/#rules)); mypy's `disable_error_code` ignores were intentionally not ported since the codebase passes without them.

## Verification

- `uvx pre-commit run -a`: all hooks pass, ty runs right before mypy
- `uv run pytest`: 1 passed, coverage 100%