### PR TITLE
chore: remove mypy in favor of ty

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -77,7 +77,7 @@ uv python install 3.12
 Common tasks are exposed via the `Makefile`. Run `make help` to list all targets. Frequently used ones:
 
 ```bash
-make fmt       # Run pre-commit hooks (ruff, mdformat, codespell, ty, mypy, ...)
+make fmt       # Run pre-commit hooks (ruff, mdformat, codespell, ty, ...)
 make test      # Run the test suite
 make gen-docs  # Generate documentation
 make clean     # Remove caches and build artifacts
@@ -173,7 +173,7 @@ Pull requests are typically merged via **squash merge** to keep history linear.
 ## Coding Standards
 
 - **Formatting and linting**: handled by `ruff` (configured in `pyproject.toml`)
-- **Typing**: `ty` runs first with strict rules; `mypy` (with the Pydantic plugin) runs alongside during the migration; new code should be type-annotated
+- **Typing**: `ty` with strict rules, running against the project environment so first-party imports resolve; new code should be type-annotated
 - **Spelling**: enforced by `codespell` via pre-commit
 - **Notebooks**: stripped of outputs by `nbstripout`
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,7 +54,7 @@ make fmt                      # Run pre-commit hooks
 
 ### Common Commands
 
-- `make fmt` or `uv run pre-commit run -a` - Run ALL pre-commit hooks (ruff, ty, mypy, mdformat, codespell, nbstripout, gitleaks)
+- `make fmt` or `uv run pre-commit run -a` - Run ALL pre-commit hooks (ruff, ty, mdformat, codespell, nbstripout, gitleaks)
 - `make test` - Run pytest with coverage (80% minimum, fails below threshold)
 - `make clean` - Remove all build artifacts, caches, and generated docs
 - `make gen-docs` - Generate API docs from `src/` and `scripts/` into `docs/Reference/` and `docs/Scripts/`
@@ -213,7 +213,7 @@ When creating or modifying `.github/workflows/*.yml` files, adhere to the follow
 ### Code Quality (.github/workflows/code-quality-check.yml)
 
 - Runs all pre-commit hooks via `uv run pre-commit run -a`
-- Includes ruff check, ruff format, ty, mypy, and other linters
+- Includes ruff check, ruff format, ty, and other linters
 - Enforces pre-commit hook standards
 
 ### Documentation Deploy (.github/workflows/deploy.yml)
@@ -352,7 +352,7 @@ make test                     # Verify tests pass
 
 ## Critical Usage Guidelines
 
-- **After every code change, always run `uv run pre-commit run -a` (or `make fmt`) before committing to ensure all hooks (ruff, ty, mypy, mdformat, codespell, etc.) pass.**
+- **After every code change, always run `uv run pre-commit run -a` (or `make fmt`) before committing to ensure all hooks (ruff, ty, mdformat, codespell, etc.) pass.**
 - **All commit messages and PR titles must be in English and follow [Conventional Commits](https://www.conventionalcommits.org/)** (e.g. `feat: add login page`, `fix(api): handle null response`)
 - Always use `uv sync` for installing dependencies, never use `pip install`
 - Always prefix script execution with `uv run <command>` to ensure correct environment

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -117,18 +117,6 @@ repos:
         # needs every dependency group, not just the default ones.
         args: ["--all-groups"]
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.3.0
-    hooks:
-      - id: mypy
-        additional_dependencies:
-          - "Pydantic"
-          - "Types-PyYAML"
-          - "Types-requests"
-          - "Types-urllib3"
-          - "Types-redis"
-          - "Types-attrs"
-
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.30.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Other Languages: [English](README.md) | [繁體中文](README.zh-TW.md) | [简�
 
 - Modern `src/` layout and type‑hinted code
 - Fast dependency management via `uv`
-- Pre‑commit suite: ruff, mdformat(+plugins), codespell, nbstripout, ty, mypy, uv hooks
-- Strong typing: ty with strict rules; mypy runs alongside during the migration
+- Pre‑commit suite: ruff, mdformat(+plugins), codespell, nbstripout, ty, uv hooks
+- Strong typing: ty with strict rules, checked against the real project environment
 - Pytest with coverage and xdist; PR coverage summary comment
 - Coverage gate at 80% with HTML/XML reports committed under `.github/`
 - Zensical with mkdocstrings (inheritance diagrams), markdown‑exec, MathJax

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,8 +29,8 @@
 
 - 现代 `src/` 布局 + 全面类型注解
 - `uv` 超快依赖管理
-- pre-commit 包链：ruff、mdformat（含多插件）、codespell、nbstripout、ty、mypy、uv hooks
-- 类型严谨：ty 严格规则；迁移期间与 mypy 并行
+- pre-commit 包链：ruff、mdformat（含多插件）、codespell、nbstripout、ty、uv hooks
+- 类型严谨：ty 严格规则，直接针对项目实际环境检查
 - pytest + coverage + xdist；PR 覆盖率摘要留言
     - 覆盖率门槛 80%，HTML/XML 报告输出至 `.github/`
 - Zensical + mkdocstrings（继承图）、markdown-exec、MathJax

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -29,8 +29,8 @@
 
 - 現代 `src/` 佈局 + 全面型別註解
 - `uv` 超快依賴管理
-- pre-commit 套件鏈：ruff、mdformat（含多插件）、codespell、nbstripout、ty、mypy、uv hooks
-- 型別嚴謹：ty 嚴格規則；遷移期間與 mypy 並行
+- pre-commit 套件鏈：ruff、mdformat（含多插件）、codespell、nbstripout、ty、uv hooks
+- 型別嚴謹：ty 嚴格規則，直接針對專案實際環境檢查
 - pytest + coverage + xdist；PR 覆蓋率摘要留言
     - 覆蓋率門檻 80%，HTML/XML 報告輸出至 `.github/`
 - Zensical + mkdocstrings（繼承圖）、markdown-exec、MathJax

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -497,6 +497,11 @@ missing-type-argument = "error"
 possibly-unresolved-reference = "warn"
 unsupported-dynamic-base = "warn"
 
+# `error-on-warning` has been ty's default since 0.0.52, so warn-level rules gate too.
+# These two are stated as errors so they keep gating if that 0.0.x default flips back.
+pydantic-discarded-extra-argument = "error"
+redundant-cast = "error"
+
 # NOTE: the following rules are known to have a significant number of false positives,
 # which is mostly unavoidable. Enable them at your own risk!
 division-by-zero = "warn"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,6 @@ exclude = [
     "/.nox",
     "/.cache",
     "/.pytest_cache",
-    "/.mypy_cache",
     "/.tox",
     "/.venv",
     "/.git",
@@ -486,7 +485,9 @@ ignore-words-list = ["ameba", "mke"]
 #         ty         #
 # ================== #
 
-# Gradually migrating from mypy to ty; ty runs before mypy in pre-commit.
+# ty is the only type checker. mypy was dropped because its pre-commit hook ran in an
+# isolated venv that could not resolve this package, so it reported success on code it
+# never checked; see #406.
 # https://docs.astral.sh/ty/reference/configuration
 # https://docs.astral.sh/ty/reference/rules
 # Based on: https://docs.astral.sh/ty/coming-from-mypy-or-pyright/#stricter-checking-with-ty
@@ -504,40 +505,3 @@ possibly-missing-import = "warn"
 
 [tool.ty.analysis]
 strict-literal-narrowing = true
-
-
-# ================== #
-#        Mypy        #
-# ================== #
-
-[tool.mypy]
-plugins = ["pydantic.mypy"]
-# strict = true
-explicit_package_bases = true
-cache_dir = "~/.cache/.mypy_cache"
-# exclude = ["^tests/"]
-ignore_missing_imports = true
-warn_unused_configs = true
-warn_return_any = false
-warn_redundant_casts = true
-warn_unused_ignores = true
-disable_error_code = ["attr-defined", "prop-decorator"]
-follow_imports = "silent"
-
-# from https://blog.wolt.com/engineering/2021/09/30/professional-grade-mypy-configuration/
-# no_implicit_reexport = true
-# no_implicit_optional = true
-# check_untyped_defs = true
-# show_error_codes = true
-
-# disallow_untyped_defs = true
-# disallow_incomplete_defs = true
-# disallow_any_generics = true
-# disallow_untyped_decorators = true
-# disallow_any_unimported = true
-
-[tool.pydantic-mypy]
-init_forbid_extra = true
-init_typed = true
-warn_required_dynamic_aliases = false
-warn_untyped_fields = true


### PR DESCRIPTION
Closes #406.

The template drops mypy. `ty` stays as the only type checker.

## Why removal rather than repair

The two hooks did not see the same tree. `mirrors-mypy` runs in pre-commit's own isolated venv, where this package is not installed and `[tool.mypy]` set no `mypy_path`, so every first-party import resolved to `Any`; `ignore_missing_imports = true` then turned that into a silent pass. The `ty` hook runs `uv check --preview-features=check-command`, which uses the project environment uv already manages, so first-party imports and real dependencies resolve.

Repairing mypy means giving it both halves it was missing, a `mypy_path` and a real environment, which is what `ty` already has for free. A second checker is only worth its maintenance if it catches something the first does not, and on the code this template actually ships it does not: `disable_error_code = ["attr-defined", "prop-decorator"]` silenced the one class it could still have caught here, and the pydantic plugin was blind to the rest (see Verification).

Mai0313/discordbot removed mypy in Mai0313/discordbot#384, so this also closes the divergence on a template-managed file before the next scaffold sync reintroduces the hook there.

## What changed

- `.pre-commit-config.yaml`: the `mirrors-mypy` block and its `additional_dependencies`.
- `pyproject.toml`: `[tool.mypy]`, `[tool.pydantic-mypy]`, and the now-dead `/.mypy_cache` entry in the hatch sdist `exclude`. The `ty` section comment no longer describes a migration.
- `pydantic-discarded-extra-argument` and `redundant-cast` are stated as `error`. This is not a behavior change today: `error-on-warning` has been ty's default since 0.0.52, so warn-level rules already exit non-zero (verified: a lone `division-by-zero` warning fails the hook with exit 1). Stating the level keeps these two gating if that `0.0.x` default flips back, as it flipped once already.
- Docs that advertised the hook chain or the typing policy: the three READMEs, `.github/CONTRIBUTING.md`, `.github/copilot-instructions.md`.

The mypy entries in `.gitignore`, `.dockerignore` and `.github/labeler.yml` stay. They are generic scaffold boilerplate, they gate nothing, and a project scaffolded from this template is still free to add mypy back on its own.

No workflow referenced mypy, so deleting the hook is the whole CI change. The tree has no `# type: ignore` comments and no `# mypy:` directives, and mypy was in no dependency group or lockfile, so nothing needed migrating.

## Verification

The point of the issue is that a green gate meant nothing, so the remaining gate was checked against a deliberate error rather than only checked for green. A throwaway `src/repo_template/_probe.py` calling `Response(name=1, content="x")` and then `r.nmae`:

```
error[invalid-argument-type]: Argument is incorrect
 --> src/repo_template/_probe.py:5:18
  |
5 |     r = Response(name=1, content="x")
  |                  ^^^^^^ Expected `LaxStr`, found `Literal[1]`

error[unresolved-attribute]: Object of type `Response` has no attribute `nmae`
 --> src/repo_template/_probe.py:6:11
```

The hook exits 1. The probe was deleted afterwards.

The removed hook, re-run on the same probe against `main`'s tree, reports `Success: no issues found`. Both findings survive that comparison for a different reason each, and neither is the one you would guess:

- `unresolved-attribute` was silenced by `disable_error_code = ["attr-defined"]`. Restoring `MYPYPATH=src` and clearing `disable_error_code` does surface it, so this half is the isolated venv plus the disabled code, together.
- `invalid-argument-type` was never within reach. The pydantic mypy plugin synthesizes a typed `__init__` only for models whose fields carry no dynamic alias; every `Response` field sets `validation_alias=AliasChoices(...)`, which degrades the signature to `**kwargs: Any`. Confirmed on a minimal pair under the removed config: `Plain(name=1)` reports `[arg-type]`, the same model with a `validation_alias` reports nothing.

That second point is also why `[tool.pydantic-mypy] init_forbid_extra = true` bought this template nothing: on `Response` it can produce neither a finding nor the false positives it produced downstream.

- `uv run pre-commit run -a` — green with `ty` alone.
- `uv run pytest` — 1 passed, coverage gate met.
