### PR TITLE
ci: fix changelog grouping and track the labeler on its major tag

### DIFF
--- a/.github/cliff.toml
+++ b/.github/cliff.toml
@@ -82,7 +82,7 @@ commit_parsers = [
   { message = "^fix(\\(.+\\))?:", group = "<!-- 1 -->🐛 Bug Fixes" },
   # refactor bumps minor version (not just patch)
   { message = "^refactor(\\(.+\\))?:", group = "<!-- 2 -->🚜 Refactor", increment = "Minor" },
-  { message = "^doc(\\(.+\\))?:", group = "<!-- 3 -->📚 Documentation" },
+  { message = "^docs?(\\(.+\\))?:", group = "<!-- 3 -->📚 Documentation" },
   { message = "^perf(\\(.+\\))?:", group = "<!-- 4 -->⚡ Performance" },
   { message = "^style(\\(.+\\))?:", group = "<!-- 5 -->🎨 Styling" },
   { message = "^test(\\(.+\\))?:", group = "<!-- 6 -->🧪 Testing" },

--- a/.github/workflows/auto_labeler.yml
+++ b/.github/workflows/auto_labeler.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Labeler
         id: labeler
-        uses: actions/labeler@v7.0.0
+        uses: actions/labeler@v7
         with:
           sync-labels: true
           configuration-path: .github/labeler.yml


### PR DESCRIPTION
Two follow-ups to #424, which had already merged and could not carry them.

The changelog parser in `.github/cliff.toml` matched `^doc(\(.+\))?:` only, so every `docs:` commit fell through to the Other section instead of the Documentation group. The pattern now accepts both spellings.

`auto_labeler.yml` pinned `actions/labeler` to the exact `v7.0.0` tag, which means patch releases have to be picked up by hand. It now tracks the `v7` major tag.

Opened-by: Claude Opus 5 (1M context)