### PR TITLE
ci: write the labeler configuration in english

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,11 +1,16 @@
-# 依分支名稱自動為 PR 掛上一個 type label。
+# Applies one type label to a pull request, based on the name of its branch.
 #
-# 只看 head-branch,不看檔案路徑,因為路徑說不出「這是修 bug」還是「這是新功能」。
-# 唯一的例外是 chore:一個只動到工具鏈的 PR 就真的是雜務,而 any-glob-to-all-files
-# 要求「所有」改動檔案都符合,不會像 any-glob-to-any-file 那樣碰到一個就中。
+# Only head-branch is matched, never file paths, because a path cannot say
+# whether a change is a bugfix or a new feature. The single exception is chore:
+# a pull request that touches nothing but tooling really is maintenance, and
+# any-glob-to-all-files requires *every* changed file to match, so it will not
+# fire on a change that merely happens to touch one of these paths.
 #
-# 顏色和描述沒辦法寫在這裡,由 .github/workflows/sync_labels.yml 維護。
-# 這份設定與語言無關,所有 template 和下游 repo 共用同一份。
+# Colors and descriptions cannot be declared here; the labels themselves are
+# owned by .github/workflows/sync_labels.yml.
+#
+# These rules are language agnostic, so every template and every downstream
+# repository carries this file unchanged.
 
 breaking:
   - head-branch: ["^breaking/"]

--- a/.github/workflows/sync_labels.yml
+++ b/.github/workflows/sync_labels.yml
@@ -24,8 +24,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          # --force 讓已存在的 label 更新顏色和描述,不存在的就建出來。
-          # 沒有這一步,actions/labeler 會自己補建,但它只能給名字,顏色一律是灰的。
+          # --force creates a missing label and updates the color and description
+          # of one that already exists. Without this step actions/labeler still
+          # creates the labels it needs, but it can only supply a name, so every
+          # label ends up the same default grey.
           sync() { gh label create "$1" --color "$2" --description "$3" --force; }
 
           sync breaking      B60205 "Breaks compatibility and bumps the major version"
@@ -37,5 +39,6 @@ jobs:
           sync documentation 0075CA "Improvements or additions to documentation"
           sync chore         CFD3D7 "Maintenance, CI, build and tooling"
 
-          # Dependabot 自己會建這個,labeler.yml 不管它,這裡只統一顏色。
+          # Dependabot creates this one itself and labeler.yml leaves it alone.
+          # Syncing it here only keeps the color the same across repos.
           sync dependencies  0366D6 "Pull requests that update a dependency file"


### PR DESCRIPTION
Everything under `.github/` is written in English, and these two files were the only ones that were not.

Comments only. No label, rule, color, or description changes.

Opened-by: Claude Opus 5 (1M context)